### PR TITLE
Fix Meeting Record Attatchment Links

### DIFF
--- a/pages/meeting/April-25-2024-Open-Government-Data-Forum.md
+++ b/pages/meeting/April-25-2024-Open-Government-Data-Forum.md
@@ -5,8 +5,8 @@ body-class: about
 permalink: /meeting/April-25-2024-Open-Government-Data-Forum/
 ---
 
-* [Agenda](assets/files/04252024-Open-Government-Data-Forum-Agenda.pdf)
-* [Meeting slides](assets/files/04252024-Open-Data-Forum-Slides.pdf)
+* [Agenda](/assets/files/04252024-Open-Government-Data-Forum-Agenda.pdf)
+* [Meeting slides](/assets/files/04252024-Open-Data-Forum-Slides.pdf)
 * Meeting Overview & Notes (Coming Soon)
 
 ## Agenda

--- a/pages/meeting/february-2024-public-meeting.md
+++ b/pages/meeting/february-2024-public-meeting.md
@@ -5,7 +5,7 @@ body-class: about
 permalink: /meeting/february-2024-public-meeting/
 ---
 
-* [Agenda](assets/files/02052024-Open-Government-Secretariat-Open-Government-Roundtable-Civil-Society-Meeting-Agenda.pdf)
+* [Agenda](/assets/files/02052024-Open-Government-Secretariat-Open-Government-Roundtable-Civil-Society-Meeting-Agenda.pdf)
 * [Meeting slides](/assets/files/02.05.24_Open_Government_Secretariat_and_Open_Government_Roundtable_Civil_Society_Meeting_.pptx)
 * [Meeting Overview & Notes](/assets/files/02.05.24_Engagement_Session_Meeting_Overview.pdf)
 * [Miro Board Activity Screen Captures](/assets/files/2-5-24-DC-Civil-Society-Meetup-(GSA).pdf)


### PR DESCRIPTION
Fixed the meeting record attachement links for the Feb and April 2024 meeting record pages.