### PR TITLE
Video for May 29. 2024 public meeting

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -11,7 +11,7 @@ This site outlines initiatives on openness, transparency and public participatio
 
 * [Fifth National Action Plan for Open Government (2022-2024)](/national-action-plan/5/) ([Commitment Tracker](/national-action-plan/5/commitments/)) (Updated March 26, 2024)
 
-* [Public Meetings](/national-action-plan/5/schedule-of-open-govt-public-meetings/) (Updated June 4, 2024)
+* [Public Meetings](/national-action-plan/5/schedule-of-open-govt-public-meetings/) (Updated June 5, 2024)
 
 * Read the [press release](https://www.whitehouse.gov/ostp/news-updates/2022/12/28/white-house-releases-fifth-open-government-national-action-plan-to-advance-a-more-inclusive-responsive-and-accountable-government/) for the Fifth U.S. National Action Plan for Open Government on [WhiteHouse.gov](https://www.whitehouse.gov/ostp/news-updates/2022/12/28/white-house-releases-fifth-open-government-national-action-plan-to-advance-a-more-inclusive-responsive-and-accountable-government/)
 

--- a/pages/meeting/May-29-2024-Open-Gov-Week.md
+++ b/pages/meeting/May-29-2024-Open-Gov-Week.md
@@ -14,7 +14,10 @@ permalink: /meeting/May-29-2024-Open-Gov-Week/
 This session will explore ways in which open government approaches are strengthening democracy and improving communities at the federal, state, local, Tribal, and territorial (SLTT) levels across the United States. Featuring experiences from across the country, SLTT and federal leaders will discuss opportunities and challenges in open government and share lessons learned.
 
 ## Recording of the Meeting
-Comming Soon
+
+<div class="video-container" style="margin-bottom: 5em">
+<iframe width="560" height="315" src="https://www.youtube.com/embed/w8Y0-gdp4O0?si=4Hxam81uJOQvlPRF" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 
 
 ---

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -4,7 +4,7 @@ body-class: nap4
 title: "Schedule of Open Govt Public Meetings"
 permalink: /national-action-plan/5/schedule-of-open-govt-public-meetings/
 ---
-_Updated June 4 2024_
+_Updated June 6 2024_
 
 Welcome to our Public Meetings page, where you can view details about upcoming events and access records from past gatherings. You’ll find meeting agendas, registration links, and a variety of resources from previous events, including slides, notes, and recordings. We hope these tools will help you stay informed and actively participate in the important discussion around transparency, government accountability, and civil participation in the U.S..<br><br>
 

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -4,7 +4,7 @@ body-class: nap4
 title: "Schedule of Open Govt Public Meetings"
 permalink: /national-action-plan/5/schedule-of-open-govt-public-meetings/
 ---
-_Updated June 6 2024_
+_Updated June 5 2024_
 
 Welcome to our Public Meetings page, where you can view details about upcoming events and access records from past gatherings. You’ll find meeting agendas, registration links, and a variety of resources from previous events, including slides, notes, and recordings. We hope these tools will help you stay informed and actively participate in the important discussion around transparency, government accountability, and civil participation in the U.S..<br><br>
 


### PR DESCRIPTION
Added a link to the recording of the meeting record page for the May 29, 2024 session as well as updated the public meeting last udpated date on the home page and public meeting page. 