### PR TITLE
Updated Public meetings page

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -11,7 +11,7 @@ This site outlines initiatives on openness, transparency and public participatio
 
 * [Fifth National Action Plan for Open Government (2022-2024)](/national-action-plan/5/) ([Commitment Tracker](/national-action-plan/5/commitments/)) (Updated March 26, 2024)
 
-* [Public Meetings](/national-action-plan/5/schedule-of-open-govt-public-meetings/) (Updated June 21, 2024)
+* [Public Meetings](/national-action-plan/5/schedule-of-open-govt-public-meetings/) (Updated July 5, 2024)
 
 * Read the [press release](https://www.whitehouse.gov/ostp/news-updates/2022/12/28/white-house-releases-fifth-open-government-national-action-plan-to-advance-a-more-inclusive-responsive-and-accountable-government/) for the Fifth U.S. National Action Plan for Open Government on [WhiteHouse.gov](https://www.whitehouse.gov/ostp/news-updates/2022/12/28/white-house-releases-fifth-open-government-national-action-plan-to-advance-a-more-inclusive-responsive-and-accountable-government/)
 

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -4,14 +4,12 @@ body-class: nap4
 title: "Schedule of Open Govt Public Meetings"
 permalink: /national-action-plan/5/schedule-of-open-govt-public-meetings/
 ---
-_Updated June 21 2024_
+_Updated July 5 2024_
 
 Welcome to our Public Meetings page, where you can view details about upcoming events and access records from past gatherings. You’ll find meeting agendas, registration links, and a variety of resources from previous events, including slides, notes, and recordings. We hope these tools will help you stay informed and actively participate in the important discussion around transparency, government accountability, and civil participation in the U.S..<br><br>
 
 
-### Upcoming Meeting:
-
-**June 24, 2024** - The [NTIS Federal Advisory Committee](https://www.federalregister.gov/documents/2024/04/15/2024-07918/national-technical-information-service-advisory-board#mai) has asked the U.S. Open Government Secretariat to speak at their meeting on June 24, 2024, which runs from 12:30 PM to 4:30 PM ET. You can find the agenda and additional information [HERE](https://www.ntis.gov/about/advisorybd/index.xhtml).<br><br>
+### Upcoming Meeting:<br>
 
 **July 15, 2024** - We’re pleased to invite you to join in a hybrid discussion co-organized by the U.S. Open Government Secretariat and the [Washington Coalition for Open Government (WashCOG)](https://www.washcog.org/). Hosted by Sarah Schacht and the Allgire Project on Whidbey Island, Washington, this event will introduce civil society in the Pacific Northwest to open government activities at the federal level and discuss open government at the state/local level. We intend for this gathering to be both informational and participatory, and we hope to include speakers from both government and civil society. The first hour will feature presentations covering topics that range from defining open government as a concept, to examining open government efforts at the state and federal levels. The second half will be in person only and will feature a breakout group activity. 
 * **Date:** Monday, July 15th, 2024


### PR DESCRIPTION
Removed June 24th NTIS Federal Advisory Committee entry from the public meetings page