### PR TITLE
Add Video link for July 15, 2024 PNW Event

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -11,7 +11,7 @@ This site outlines initiatives on openness, transparency and public participatio
 
 * [Fifth National Action Plan for Open Government (2022-2024)](/national-action-plan/5/) ([Commitment Tracker](/national-action-plan/5/commitments/)) (Updated March 26, 2024)
 
-* [Public Meetings](/national-action-plan/5/schedule-of-open-govt-public-meetings/) (Updated July 17, 2024)
+* [Public Meetings](/national-action-plan/5/schedule-of-open-govt-public-meetings/) (Updated July 18, 2024)
 
 * Read the [press release](https://www.whitehouse.gov/ostp/news-updates/2022/12/28/white-house-releases-fifth-open-government-national-action-plan-to-advance-a-more-inclusive-responsive-and-accountable-government/) for the Fifth U.S. National Action Plan for Open Government on [WhiteHouse.gov](https://www.whitehouse.gov/ostp/news-updates/2022/12/28/white-house-releases-fifth-open-government-national-action-plan-to-advance-a-more-inclusive-responsive-and-accountable-government/)
 

--- a/pages/meeting/July-15-2024-WashCOG.md
+++ b/pages/meeting/July-15-2024-WashCOG.md
@@ -1,8 +1,8 @@
 ---
 layout: home
-title: July 16, 2024 PNW Open Government Event
+title: July 15, 2024 PNW Open Government Event
 body-class: about
-permalink: /meeting/July-16-2024-WashCOG/ 
+permalink: /meeting/July-15-2024-WashCOG/ 
 ---
 
 

--- a/pages/meeting/July-16-2024-WashCOG.md
+++ b/pages/meeting/July-16-2024-WashCOG.md
@@ -16,8 +16,8 @@ permalink: /meeting/July-16-2024-WashCOG/
 ## Agenda
 We’re pleased to invite you to join in a hybrid discussion co-organized by the U.S. Open Government Secretariat and the [Washington Coalition for Open Government (WashCOG)](https://www.washcog.org/). Hosted by Sarah Schacht and the Allgire Project on Whidbey Island, Washington, this event will introduce civil society in the Pacific Northwest to open government activities at the federal level and discuss open government at the state/local level. We intend for this gathering to be both informational and participatory, and we hope to include speakers from both government and civil society. The first hour will feature presentations covering topics that range from defining open government as a concept, to examining open government efforts at the state and federal levels. The second half will be in person only and will feature a breakout group activity.
 
-## Recording of the Meeting
-Coming Soon
+## Recording of the Meeting <br>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/q213n-khhrQ?si=nmSInFNsXbKl1Yvw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 
 ---

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -4,7 +4,7 @@ body-class: nap4
 title: "Schedule of Open Govt Public Meetings"
 permalink: /national-action-plan/5/schedule-of-open-govt-public-meetings/
 ---
-_Updated July 17 2024_
+_Updated July 18 2024_
 
 Welcome to our Public Meetings page, where you can view details about upcoming events and access records from past gatherings. You’ll find meeting agendas, registration links, and a variety of resources from previous events, including slides, notes, and recordings. We hope these tools will help you stay informed and actively participate in the important discussion around transparency, government accountability, and civil participation in the U.S..<br><br>
 
@@ -19,7 +19,7 @@ Welcome to our Public Meetings page, where you can view details about upcoming e
 ### Past Meetings:
 
 #### July 2024
-* July 16, 2024 - 10:00 AM - 2:00 PM PT (1:00 - 5:00 PM ET) - PNW Open Government Event -[Meeting Record](/meeting/July-16-2024-WashCOG/)
+* July 16, 2024 - 10:00 AM - 2:00 PM PT (1:00 - 5:00 PM ET) - PNW Open Government Event -[Meeting Record](/meeting/July-15-2024-WashCOG/)
 
 #### May 2024
 * May 2, 1:30 p.m. - 3:00 p.m. ET – Public Participation and Community Engagement (PPCE) RFI Listening Session – [Meeting Record](/meeting/May-2-2024-PPCE-RFI-listening-session/)

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -19,7 +19,7 @@ Welcome to our Public Meetings page, where you can view details about upcoming e
 ### Past Meetings:
 
 #### July 2024
-* July 16, 2024 - 10:00 AM - 2:00 PM PT (1:00 - 5:00 PM ET) - PNW Open Government Event -[Meeting Record](/meeting/July-15-2024-WashCOG/)
+* July 15, 2024 - 10:00 AM - 2:00 PM PT (1:00 - 5:00 PM ET) - PNW Open Government Event -[Meeting Record](/meeting/July-15-2024-WashCOG/)
 
 #### May 2024
 * May 2, 1:30 p.m. - 3:00 p.m. ET – Public Participation and Community Engagement (PPCE) RFI Listening Session – [Meeting Record](/meeting/May-2-2024-PPCE-RFI-listening-session/)


### PR DESCRIPTION
Added a youtube link to the July 15, 2024 meetings record page and made some text updates on the public meeings page.