### PR TITLE
added a notice that the website is moving bannor

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -4,7 +4,8 @@ title: About
 body-class: about
 permalink: /about/
 ---
-
+<span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
 This site outlines initiatives on openness, transparency and public participation, pursuant to the U.S. National Action Plans. 
 
 ## Public Engagement Guidelines

--- a/pages/home.md
+++ b/pages/home.md
@@ -4,9 +4,9 @@ body-class: home
 title: "U.S. Open Government Initiatives"
 permalink: /
 ---
-> **⚠ Important Notice: This website is moving!** <br> Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support!
+**⚠ Important Notice: This website is moving!** <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support!
 
----
 <img src="/assets/files/Open_Govt_Logo.png" alt="The U.S. Open Government Secretariat logo. It has an outline of a blue star, that has the words U.S. Open Government in red text and the word Secretariat in blue text" width="700" height="300"> <br>
 
 This site outlines initiatives on openness, transparency and public participation, pursuant to the U.S. National Action Plans. 

--- a/pages/home.md
+++ b/pages/home.md
@@ -4,8 +4,8 @@ body-class: home
 title: "U.S. Open Government Initiatives"
 permalink: /
 ---
-**⚠ Important Notice: This website is moving!** <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support!
+<span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br>
 
 <img src="/assets/files/Open_Govt_Logo.png" alt="The U.S. Open Government Secretariat logo. It has an outline of a blue star, that has the words U.S. Open Government in red text and the word Secretariat in blue text" width="700" height="300"> <br>
 

--- a/pages/home.md
+++ b/pages/home.md
@@ -4,9 +4,7 @@ body-class: home
 title: "U.S. Open Government Initiatives"
 permalink: /
 ---
-> **⚠ Important Notice: This website is moving!**
->
-> Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support!
+> **⚠ Important Notice: This website is moving!** <br> Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support!
 
 ---
 <img src="/assets/files/Open_Govt_Logo.png" alt="The U.S. Open Government Secretariat logo. It has an outline of a blue star, that has the words U.S. Open Government in red text and the word Secretariat in blue text" width="700" height="300"> <br>

--- a/pages/home.md
+++ b/pages/home.md
@@ -4,6 +4,11 @@ body-class: home
 title: "U.S. Open Government Initiatives"
 permalink: /
 ---
+> **⚠ Important Notice: This website is moving!**
+>
+> Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support!
+
+---
 <img src="/assets/files/Open_Govt_Logo.png" alt="The U.S. Open Government Secretariat logo. It has an outline of a blue star, that has the words U.S. Open Government in red text and the word Secretariat in blue text" width="700" height="300"> <br>
 
 This site outlines initiatives on openness, transparency and public participation, pursuant to the U.S. National Action Plans. 

--- a/pages/mailing-list.md
+++ b/pages/mailing-list.md
@@ -4,7 +4,8 @@ title: Open Government Mailing Lists
 body-class: about
 permalink: /mailing-list/
 ---
-
+<span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br>
 We host two open government listservs. The purpose of the GSA OpenGov-CIV ListServ is for single-directional messages from GSA that keep the public informed on various open government-related announcements, activities, and opportunities to participate. The other is a government-only listserv and is primarily to disseminate government specific information on timelines and deadlines for the NAP and offer support as agencies work to achieve their commitments.
 
 * **Public**: Please subscribe if you are interested staying up to date on open government-related announcements, activities, and opportunities to participate.

--- a/pages/mailing-list.md
+++ b/pages/mailing-list.md
@@ -5,7 +5,7 @@ body-class: about
 permalink: /mailing-list/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
 We host two open government listservs. The purpose of the GSA OpenGov-CIV ListServ is for single-directional messages from GSA that keep the public informed on various open government-related announcements, activities, and opportunities to participate. The other is a government-only listserv and is primarily to disseminate government specific information on timelines and deadlines for the NAP and offer support as agencies work to achieve their commitments.
 
 * **Public**: Please subscribe if you are interested staying up to date on open government-related announcements, activities, and opportunities to participate.

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -11,7 +11,7 @@ Welcome to our Public Meetings page, where you can view details about upcoming e
 
 ### Upcoming Meeting:<br>
 
-**September 17, 2024 - <span style="color:red">SAVE THE DATE</span>** - The U.S. Open Government Secretariat and the City of Austin government officials are organizing an in-person event with the [City of Austin, TX,](https://www.austintexas.gov/department/open-government-information) and local civil society. More information on this session will be coming out in the coming months. <br><br>
+**September 17, 2024** - The U.S. Open Government Secretariat and the City of Austin government officials are organizing an in-person only event with the [City of Austin, TX,](https://www.austintexas.gov/department/open-government-information) and local civil society. The City of Austin will be sending invitations to local civil society organizations in the coming weeks. <br><br>
 
 **December 3-6, 2024** - [Open Government Partnership](https://www.opengovpartnership.org/about/) will  hold an Americas Regional Meeting in Brasilia, Brazil. This is a unique opportunity to bring together the open government and open data communities for four days of exchanging experiences, innovative ideas/initiatives, and recognizing ambitious reforms in the Americas. You can find more information [HERE](https://www.gov.br/cgu/pt-br/acesso-a-informacao/institucional/eventos/america-aberta/open-america).<br><br><br>
 

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -5,7 +5,7 @@ title: "Schedule of Open Govt Public Meetings"
 permalink: /national-action-plan/5/schedule-of-open-govt-public-meetings/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
 _Updated Aug 16 2024_
 
 Welcome to our Public Meetings page, where you can view details about upcoming events and access records from past gatherings. You’ll find meeting agendas, registration links, and a variety of resources from previous events, including slides, notes, and recordings. We hope these tools will help you stay informed and actively participate in the important discussion around transparency, government accountability, and civil participation in the U.S..<br><br>

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -4,7 +4,9 @@ body-class: nap4
 title: "Schedule of Open Govt Public Meetings"
 permalink: /national-action-plan/5/schedule-of-open-govt-public-meetings/
 ---
-_Updated Aug 8 2024_
+<span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br>
+_Updated Aug 16 2024_
 
 Welcome to our Public Meetings page, where you can view details about upcoming events and access records from past gatherings. You’ll find meeting agendas, registration links, and a variety of resources from previous events, including slides, notes, and recordings. We hope these tools will help you stay informed and actively participate in the important discussion around transparency, government accountability, and civil participation in the U.S..<br><br>
 

--- a/pages/nap/5/NAP5-Self-Assessment.md
+++ b/pages/nap/5/NAP5-Self-Assessment.md
@@ -4,7 +4,8 @@ body-class: about
 title: "Mid-Term Self-Assessment Report of the United States' 5th Open Government National Action Plan"
 permalink: /national-action-plan/5/NAP5-Self-Assessment/
 ---
-
+<span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
 _Posted August 5, 2024_
 
 Please find below the 5th Open Government National Action Plan of the United States' Mid-Term Self-Assessment Report 2022-2024 that the U.S. Open Government Secretariat submited to the Open Government Partnership on August 5, 2024.

--- a/pages/nap/5/commitments.md
+++ b/pages/nap/5/commitments.md
@@ -5,5 +5,6 @@ title: "Fifth U.S. Open Government National Action Plan
 Commitment Tracker"
 permalink: /national-action-plan/5/commitments/
 ---
-
+<span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
 This is the initial beta version of the [Fifth U.S. Open Government National Action Plan](/national-action-plan/5/) Commitment Tracker which includes a sampling of commitment updates. Additional commitment updates and design improvements will be released here in a sequence of iterative updates. 

--- a/pages/nap/5/nap-5.md
+++ b/pages/nap/5/nap-5.md
@@ -4,6 +4,8 @@ body-class: nap4 nap5
 title: "Fifth U.S. Open Government National Action Plan"
 permalink: /national-action-plan/5/
 ---
+<span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
+Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
 December 2022
 
 


### PR DESCRIPTION
Put up a notice of the website moving to the gsa.gov platform on Aug 29th on the most visited pages. (Home page, public meetings page, NAP5 page, NAP5 Self-Assessment page, Commitment Tracker page, and the mailing list page)