### PR TITLE
Updated Website Moving Bannor

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -5,7 +5,7 @@ body-class: about
 permalink: /about/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
+Starting **August 29, 2024**, this website will be relocated to [https://www.gsa.gov/usopengov](https://www.gsa.gov/usopengov). Please update your bookmarks, as the current site will be decommissioned shortly after the launch. Legacy URLs may take up to a week to redirect. We appreciate your continued support! <br><br>
 This site outlines initiatives on openness, transparency and public participation, pursuant to the U.S. National Action Plans. 
 
 ## Public Engagement Guidelines

--- a/pages/home.md
+++ b/pages/home.md
@@ -15,7 +15,7 @@ This site outlines initiatives on openness, transparency and public participatio
 
 * [Fifth National Action Plan for Open Government (2022-2024)](/national-action-plan/5/) ([Commitment Tracker](/national-action-plan/5/commitments/)) (Updated March 26, 2024)
 
-* [Public Meetings](/national-action-plan/5/schedule-of-open-govt-public-meetings/) (Updated Aug 8, 2024)
+* [Public Meetings](/national-action-plan/5/schedule-of-open-govt-public-meetings/) (Updated Aug 23, 2024)
 
 * Read the [press release](https://www.whitehouse.gov/ostp/news-updates/2022/12/28/white-house-releases-fifth-open-government-national-action-plan-to-advance-a-more-inclusive-responsive-and-accountable-government/) for the Fifth U.S. National Action Plan for Open Government on [WhiteHouse.gov](https://www.whitehouse.gov/ostp/news-updates/2022/12/28/white-house-releases-fifth-open-government-national-action-plan-to-advance-a-more-inclusive-responsive-and-accountable-government/)
 

--- a/pages/home.md
+++ b/pages/home.md
@@ -5,7 +5,7 @@ title: "U.S. Open Government Initiatives"
 permalink: /
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br>
+Starting **August 29, 2024**, this website will be relocated to [https://www.gsa.gov/usopengov](https://www.gsa.gov/usopengov). Please update your bookmarks, as the current site will be decommissioned shortly after the launch. Legacy URLs may take up to a week to redirect. We appreciate your continued support! <br>
 
 <img src="/assets/files/Open_Govt_Logo.png" alt="The U.S. Open Government Secretariat logo. It has an outline of a blue star, that has the words U.S. Open Government in red text and the word Secretariat in blue text" width="700" height="300"> <br>
 

--- a/pages/mailing-list.md
+++ b/pages/mailing-list.md
@@ -5,7 +5,7 @@ body-class: about
 permalink: /mailing-list/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
+Starting **August 29, 2024**, this website will be relocated to [https://www.gsa.gov/usopengov](https://www.gsa.gov/usopengov). Please update your bookmarks, as the current site will be decommissioned shortly after the launch. Legacy URLs may take up to a week to redirect. We appreciate your continued support! <br><br>
 We host two open government listservs. The purpose of the GSA OpenGov-CIV ListServ is for single-directional messages from GSA that keep the public informed on various open government-related announcements, activities, and opportunities to participate. The other is a government-only listserv and is primarily to disseminate government specific information on timelines and deadlines for the NAP and offer support as agencies work to achieve their commitments.
 
 * **Public**: Please subscribe if you are interested staying up to date on open government-related announcements, activities, and opportunities to participate.

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -6,7 +6,7 @@ permalink: /national-action-plan/5/schedule-of-open-govt-public-meetings/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
 Starting **August 29, 2024**, this website will be relocated to [https://www.gsa.gov/usopengov](https://www.gsa.gov/usopengov). Please update your bookmarks, as the current site will be decommissioned shortly after the launch. Legacy URLs may take up to a week to redirect. We appreciate your continued support! <br><br>
-_Updated Aug 16 2024_
+_Updated Aug 23 2024_
 
 Welcome to our Public Meetings page, where you can view details about upcoming events and access records from past gatherings. You’ll find meeting agendas, registration links, and a variety of resources from previous events, including slides, notes, and recordings. We hope these tools will help you stay informed and actively participate in the important discussion around transparency, government accountability, and civil participation in the U.S..<br><br>
 

--- a/pages/meeting/Public-Meetings.md
+++ b/pages/meeting/Public-Meetings.md
@@ -5,7 +5,7 @@ title: "Schedule of Open Govt Public Meetings"
 permalink: /national-action-plan/5/schedule-of-open-govt-public-meetings/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
+Starting **August 29, 2024**, this website will be relocated to [https://www.gsa.gov/usopengov](https://www.gsa.gov/usopengov). Please update your bookmarks, as the current site will be decommissioned shortly after the launch. Legacy URLs may take up to a week to redirect. We appreciate your continued support! <br><br>
 _Updated Aug 16 2024_
 
 Welcome to our Public Meetings page, where you can view details about upcoming events and access records from past gatherings. You’ll find meeting agendas, registration links, and a variety of resources from previous events, including slides, notes, and recordings. We hope these tools will help you stay informed and actively participate in the important discussion around transparency, government accountability, and civil participation in the U.S..<br><br>

--- a/pages/nap/5/NAP5-Self-Assessment.md
+++ b/pages/nap/5/NAP5-Self-Assessment.md
@@ -5,7 +5,7 @@ title: "Mid-Term Self-Assessment Report of the United States' 5th Open Governmen
 permalink: /national-action-plan/5/NAP5-Self-Assessment/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
+Starting **August 29, 2024**, this website will be relocated to [https://www.gsa.gov/usopengov](https://www.gsa.gov/usopengov). Please update your bookmarks, as the current site will be decommissioned shortly after the launch. Legacy URLs may take up to a week to redirect. We appreciate your continued support! <br><br>
 _Posted August 5, 2024_
 
 Please find below the 5th Open Government National Action Plan of the United States' Mid-Term Self-Assessment Report 2022-2024 that the U.S. Open Government Secretariat submited to the Open Government Partnership on August 5, 2024.

--- a/pages/nap/5/commitments.md
+++ b/pages/nap/5/commitments.md
@@ -6,5 +6,5 @@ Commitment Tracker"
 permalink: /national-action-plan/5/commitments/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
+Starting **August 29, 2024**, this website will be relocated to [https://www.gsa.gov/usopengov](https://www.gsa.gov/usopengov). Please update your bookmarks, as the current site will be decommissioned shortly after the launch. Legacy URLs may take up to a week to redirect. We appreciate your continued support! <br><br>
 This is the initial beta version of the [Fifth U.S. Open Government National Action Plan](/national-action-plan/5/) Commitment Tracker which includes a sampling of commitment updates. Additional commitment updates and design improvements will be released here in a sequence of iterative updates. 

--- a/pages/nap/5/nap-5.md
+++ b/pages/nap/5/nap-5.md
@@ -5,7 +5,7 @@ title: "Fifth U.S. Open Government National Action Plan"
 permalink: /national-action-plan/5/
 ---
 <span style="color:red;"> **⚠ Important Notice: This website is moving!** </span> <br>
-Starting **August 29, 2024**, this website will be available on the GSA.gov at a new URL. The new address will be shared here soon. Please check back for updates and be sure to update your bookmarks once the new URL is announced. Thank you for your continued support! <br><br>
+Starting **August 29, 2024**, this website will be relocated to [https://www.gsa.gov/usopengov](https://www.gsa.gov/usopengov). Please update your bookmarks, as the current site will be decommissioned shortly after the launch. Legacy URLs may take up to a week to redirect. We appreciate your continued support! <br>><br>
 December 2022
 
 


### PR DESCRIPTION
Updated the Website Moving Bannor at the top of the most visited pages to include the URL of the new Open Gov Webpage.